### PR TITLE
metal segmentation using Swin-transformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,19 @@
 
  Collection of deep learning-based metal artifact reduction articles for CT/CBCT Imaging
 
+**Simulation-driven training of vision transformers enables
+metal artifact reduction of highly truncated CBCT scans** \
+F. Fan et al.\
+**Summary** \
+The paper proposes to use Swin-transformer for metal segmentation in the projection domain for CBCT data. Simulation data is used for the training. U-Net is shown to work best when the test data is similiar to the train data. But when the test data source is different than training, Swin transformer performs better.\
+arxiv 2022. [[Paper](https://arxiv.org/abs/2203.09207)] \
+Medical Physics 2023. [[doi](https://aapm.onlinelibrary.wiley.com/doi/full/10.1002/mp.16919)] [![Open Access](https://img.shields.io/badge/Open%20Access-brightgreen.svg)](https://aapm.onlinelibrary.wiley.com/doi/full/10.1002/mp.16919)
+
+
  **Quad-Net: Quad-domain Network for CT Metal Artifact Reduction** \
 *Z. Li et al.* \
 **Summary** \
-In addition to the dual domain artifact reduction in sinogram and image domain, the paper proposed to also apply Fourier domain processing of features in sinogram and image domain, respectively.
+In addition to the dual domain artifact reduction in sinogram and image domain, the paper proposed to also apply Fourier domain processing of features in sinogram and image domain, respectively.\
 arXiv 2023. [[Paper](https://arxiv.org/abs/2207.11678)] 
 [[code](https://github.com/longzilicart/Quad-Net/tree/master)] \
 IEEE TMI 2024. [[doi](https://ieeexplore.ieee.org/document/10385220)]


### PR DESCRIPTION
Adding Simulation-driven training of vision transformers enables metal artifact reduction of highly truncated CBCT scans