### PR TITLE
Add Zenodo DOI badge, CITATION.cff, and citation section

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+message: "If you use this collection, please cite it as below."
+title: "AI-MAR-CT: A curated collection of deep learning-based metal artifact reduction papers for CT/CBCT imaging"
+authors:
+  - family-names: Agrawal
+    given-names: Harshit
+type: dataset
+repository-code: "https://github.com/harshitAgr/AI-MAR-CT"
+url: "https://github.com/harshitAgr/AI-MAR-CT"
+license: MIT
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.19651643
+    description: "Concept DOI (always resolves to the latest release)"
+  - type: doi
+    value: 10.5281/zenodo.19651644
+    description: "Version DOI for v2026.04"
+version: v2026.04
+date-released: 2026-04-08

--- a/README.md
+++ b/README.md
@@ -3,8 +3,26 @@
 
  [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Made With Love](https://img.shields.io/badge/Made%20With-Love-red.svg)](https://github.com/chetanraj/awesome-github-badges)
+[![DOI](https://zenodo.org/badge/744644178.svg)](https://doi.org/10.5281/zenodo.19651643)
 
  Collection of deep learning-based metal artifact reduction (MAR) articles for CT/CBCT Imaging.
+
+## Citation
+
+If you use this collection, please cite it via the Zenodo DOI. The **concept DOI** below always resolves to the latest release; use a specific version DOI from Zenodo for a pinned citation.
+
+```bibtex
+@misc{agrawal_ai_mar_ct,
+  author       = {Agrawal, Harshit},
+  title        = {{AI-MAR-CT: A curated collection of deep learning-based metal artifact reduction papers for CT/CBCT imaging}},
+  howpublished = {\url{https://github.com/harshitAgr/AI-MAR-CT}},
+  publisher    = {Zenodo},
+  doi          = {10.5281/zenodo.19651643},
+  url          = {https://doi.org/10.5281/zenodo.19651643}
+}
+```
+
+A `CITATION.cff` is included so GitHub renders a "Cite this repository" button in the sidebar with BibTeX/APA export.
 
  1. **FIND-Net: Fourier-Integrated Network with Dictionary Kernels for Metal Artifact Reduction** <img src="https://img.shields.io/badge/Supervised-blue.svg" alt="Supervised"> \
 *F. Tasharofi, F. Fan, M. Qahqaie, M. Thies, A. Maier* \


### PR DESCRIPTION
## Summary
- Added Zenodo concept DOI badge (`10.5281/zenodo.19651643`) to README header
- Added a **Citation** section with ready-to-copy BibTeX using the concept DOI
- Added `CITATION.cff` so GitHub renders a native "Cite this repository" button in the sidebar with BibTeX/APA export

The concept DOI always resolves to the latest release; the version-specific DOI (`10.5281/zenodo.19651644` for v2026.04) is also recorded in `CITATION.cff` for pinned citations.